### PR TITLE
Project Reboot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     glue (>= 1.3.2),
     httr (>= 1.4.1),
     jpmesh (>= 1.2.0),
-    jpndistrict (>= 0.3.4),
     kokudosuuchi (>= 0.4.2),
     lubridate (>= 1.7.4),
     magrittr (>= 1.5),
@@ -42,7 +41,5 @@ Suggests:
     rvest (>= 0.3.5),
     usethis (>= 1.5.1),
     testthat (>= 2.1.0)
-Remotes:
-    uribo/jpndistrict
 URL: https://github.com/uribo/kuniumi
 BugReports: https://github.com/uribo/kuniumi/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Reads datasets provided by National Land Numerical Information down
     and treats them as 'sf' of a R spatial objects.
 License: MIT + file LICENSE
 Depends: 
-    R (>= 3.1)
+    R (>= 4.1)
 Imports:
     cli (>= 2.0.2),
     data.table (>= 1.12.8),
@@ -32,7 +32,7 @@ Imports:
     zipangu (>= 0.2.1)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Suggests: 
     assertr (>= 2.7),
     bit64 (>= 0.9.7),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.0.0.9000
 Authors@R: c(
     person(given = "Shinya", family = "Uryu", email = "suika1127@gmail.com", role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-0493-6186"))
     )
-Description: Reads datasets provided by National Land Numerical Information download service <http://nlftp.mlit.go.jp/ksj/index.html> 
+Description: Reads datasets provided by National Land Numerical Information download service <https://nlftp.mlit.go.jp/ksj/index.html> 
     and treats them as 'sf' of a R spatial objects.
 License: MIT + file LICENSE
 Depends: 

--- a/R/read_ksj_a12.R
+++ b/R/read_ksj_a12.R
@@ -1,11 +1,10 @@
 zip_a09 <- function(year, pref_code = NULL) {
   year <- rlang::arg_match(year,
                            values = c("2006", "2011", "2018"))
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
+
   glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/A09/A09-{yy}/A09-{yy}_{pref_code}_GML.zip", # nolint
-             yy = substr(year, 3, 4))
+             yy = substr(year, 3, 4),
+             pref_code = make_prefcode(pref_code))
 }
 
 read_ksj_a09 <- function(path = NULL,
@@ -24,11 +23,9 @@ zip_a12_url <- function(year, pref_code = NULL) {
     as.character(year)
   year <- rlang::arg_match(year,
                            c("2006", "2011", "2015"))
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
   glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/A12/A12-{yy}/A12-{yy}_{pref_code}_GML.zip", # nolint
-             yy = substr(year, 3, 4))
+             yy = substr(year, 3, 4),
+             pref_code = make_prefcode(pref_code))
 }
 
 read_ksj_a12 <- function(path = NULL,

--- a/R/read_ksj_c23.R
+++ b/R/read_ksj_c23.R
@@ -1,7 +1,6 @@
 zip_c23_url <- function(pref_code) {
   pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
+    make_prefcode(pref_code)
   if (pref_code %in% c("09", "10", "11", "19", "20", "21",
                        "25", "29")) {
     rlang::abort("There is no target prefecture data.")

--- a/R/read_ksj_l02.R
+++ b/R/read_ksj_l02.R
@@ -119,7 +119,7 @@ read_ksj_l02 <- function(path = NULL, .year = NULL, .pref_code = NULL, .download
     purrr::set_names(c(common_vars,
                        status_vars,
                        "geometry")) %>%
-    dplyr::mutate(dplyr::across(where(is.character),
+    dplyr::mutate(dplyr::across(tidyselect::where(is.character),
                   .fns = ~dplyr::na_if(.x, "_"))) %>%
     dplyr::mutate(dplyr::across(.cols = c(tidyselect::starts_with("属性移動"),
                                           tidyselect::starts_with("供給施設有無"),

--- a/R/read_ksj_p07.R
+++ b/R/read_ksj_p07.R
@@ -5,8 +5,7 @@ zip_p07_url <- function(year, pref_code) {
   glue::glue(
     "https://nlftp.mlit.go.jp/ksj/gml/data/P07/P07-{year_dir}/P07-{year_dir}_{pref_code}_GML.zip", # nolint
     year_dir = substr(year, 3L, 4L),
-    pref_code = sprintf("%02d", as.numeric(pref_code)) %>%
-      jpndistrict:::prefcode_validate())
+    pref_code = make_prefcode(pref_code))
 }
 
 #' Kokudosuuchi P07 parser

--- a/R/read_ksj_p12.R
+++ b/R/read_ksj_p12.R
@@ -2,10 +2,8 @@ zip_p12_url <- function(pref_code = NULL) {
   if (is.null(pref_code))
     "https://nlftp.mlit.go.jp/ksj/gml/data/P12/P12-14/P12-14_GML.zip"
   else {
-    pref_code <-
-      sprintf("%02d", as.numeric(pref_code)) %>%
-      jpndistrict:::prefcode_validate()
-    glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P12/P12-14/P12-14_{pref_code}_GML.zip") # nolint
+    glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P12/P12-14/P12-14_{pref_code}_GML.zip", # nolint
+               pref_code = make_prefcode(pref_code))
   }
 }
 

--- a/R/read_ksj_p13.R
+++ b/R/read_ksj_p13.R
@@ -32,8 +32,6 @@ read_ksj_p13 <- function(path = NULL, .pref_code = NULL, .download = FALSE) {
 }
 
 zip_p13_url <- function(pref_code) {
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
-  glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P13/P13-11/P13-11_{pref_code}_GML.zip")
+  glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P13/P13-11/P13-11_{pref_code}_GML.zip",
+             pref_code = make_prefcode(pref_code))
 }

--- a/R/read_ksj_p13.R
+++ b/R/read_ksj_p13.R
@@ -26,7 +26,7 @@ read_ksj_p13 <- function(path = NULL, .pref_code = NULL, .download = FALSE) {
                                    P13_008 = "供用済面積",
                                    P13_009 = "都市計画決定",
                                    P13_010 = "備考")) %>%
-    dplyr::mutate(dplyr::across(where(is.character),
+    dplyr::mutate(dplyr::across(tidyselect::where(is.character),
                                 .fns = stringi::stri_trans_general,
                                 id = "nfkc"))
 }

--- a/R/read_ksj_p19.R
+++ b/R/read_ksj_p19.R
@@ -1,8 +1,6 @@
 zip_p19_url <- function(pref_code = NULL) {
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
-  glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P19/P19-12/P19-12_{pref_code}_GML.zip") # nolint
+  glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P19/P19-12/P19-12_{pref_code}_GML.zip", # nolint
+             pref_code = make_prefcode(pref_code))
 }
 
 #' Kokudosuuchi P19 parser

--- a/R/read_ksj_p23.R
+++ b/R/read_ksj_p23.R
@@ -1,7 +1,6 @@
 zip_p23_url <- function(pref_code) {
   pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
+    make_prefcode(pref_code)
   if (length(pref_code[pref_code %in% c("09", "10", "11", "19", "20", "21", "25", "29")]) > 0) # nolint
     rlang::abort("There is no target prefecture data.")
   glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P23/P23-12/P23-12_{pref_code}_GML.zip") # nolint

--- a/R/read_ksj_p34.R
+++ b/R/read_ksj_p34.R
@@ -21,7 +21,7 @@ read_ksj_p34 <- function(path = NULL, .pref_code = NULL, .download = FALSE) {
                                    P34_002 = "施設分類",
                                    P34_003 = "名称",
                                    P34_004 = "所在地")) %>%
-    dplyr::mutate(dplyr::across(where(is.character),
+    dplyr::mutate(dplyr::across(tidyselect::where(is.character),
                                 .fns = stringi::stri_trans_general,
                                 id = "nfkc"))
 }

--- a/R/read_ksj_p34.R
+++ b/R/read_ksj_p34.R
@@ -27,10 +27,8 @@ read_ksj_p34 <- function(path = NULL, .pref_code = NULL, .download = FALSE) {
 }
 
 zip_p34_url <- function(pref_code = NULL) {
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
   glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/P{file_code}/P{file_code}-{year_last2}/P{file_code}-{year_last2}_{pref_code}_GML.zip", # nolint
              file_code = "34",
-             year_last2 = "14")
+             year_last2 = "14",
+             pref_code = make_prefcode(pref_code))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,4 @@
 #' @import utils
-utils::globalVariables("where")
-
 build_req_url <- function(api = c("getKSJSummary", "getKSJURL"), ...) {
   rlang::arg_match(api)
   req_url <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -114,8 +114,7 @@ zip_l01_url <- function(year, pref_code) {
   glue::glue(
     "https://nlftp.mlit.go.jp/ksj/gml/data/L01/L01-{year_dir}/L01-{year_dir}_{pref_code}_GML.zip", # nolint
     year_dir = substr(year, 3L, 4L),
-    pref_code = sprintf("%02d", as.numeric(pref_code)) %>%
-      jpndistrict:::prefcode_validate())
+    pref_code = make_prefcode(pref_code))
 }
 
 zip_l02_url <- function(year, pref_code) {
@@ -125,8 +124,7 @@ zip_l02_url <- function(year, pref_code) {
   glue::glue(
     "https://nlftp.mlit.go.jp/ksj/gml/data/L02/L02-{year_dir}/L02-{year_dir}_{pref_code}_GML.zip", # nolint
     year_dir = substr(year, 3L, 4L),
-    pref_code = sprintf("%02d", as.numeric(pref_code)) %>%
-      jpndistrict:::prefcode_validate())
+    pref_code = make_prefcode(pref_code))
 }
 
 zip_l03a_url <- function(year, meshcode, datum = 2) {
@@ -233,16 +231,9 @@ zip_n03_url <- function(year, pref_code) {
       year == "2020" ~ "20200101",
       year == "2021" ~ "20210101",
       year == "2022" ~ "20220101")
-  paste0(
-    "https://nlftp.mlit.go.jp/ksj/gml/data/N03/N03-",
-    year,
-    "/N03-", # nolint
-    year_dir,
-    "_",
-    sprintf("%02d", as.numeric(pref_code)) %>%
-      jpndistrict:::prefcode_validate(),
-    "_GML.zip"
-  )
+  glue::glue(
+    "https://nlftp.mlit.go.jp/ksj/gml/data/N03/N03-{year}/N03-{year_dir}_{pref_code}_GML.zip",
+    pref_code = make_prefcode(pref_code))
 }
 
 zip_n02_url <- function(year) {
@@ -261,8 +252,7 @@ zip_n02_url <- function(year) {
 
 zip_w05_url <- function(pref_code) {
   pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
+    make_prefcode(pref_code)
   d <-
     tibble::tibble(
     year = c(rep("2006", 4),
@@ -293,11 +283,9 @@ zip_w05_url <- function(pref_code) {
 zip_a16 <- function(year, pref_code = NULL) {
   year <- rlang::arg_match(year,
                            values = c("2006", "2011", "2018"))
-  pref_code <-
-    sprintf("%02d", as.numeric(pref_code)) %>%
-    jpndistrict:::prefcode_validate()
   glue::glue("https://nlftp.mlit.go.jp/ksj/gml/data/A09/A09-{yy}/A09-{yy}_{pref_code}_GML.zip", # nolint
-             yy = substr(year, 3, 4))
+             yy = substr(year, 3, 4),
+             pref_code = make_prefcode(pref_code))
 }
 
 #' @importFrom utils download.file unzip
@@ -404,8 +392,14 @@ ksj_common_meshes <- function(identifier) {
 
 prefcode_validate <- function(pref_code) {
   codes <-
-    sapply(seq(1, 47, 1), sprintf, fmt = "%d")
+    sapply(seq(1, 47, 1), sprintf, fmt = "%02d")
   if (identical(codes[codes %in% pref_code], character(0)))
     rlang::abort("jis_code must be start a integer or as character from 1 to 47.")
-  as.numeric(pref_code)
+  pref_code
+}
+
+make_prefcode <- function(pref_code) {
+  prefcode_validate(
+    sprintf("%02d", as.numeric(pref_code))
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -330,7 +330,7 @@ check_dl_comment <- function(source = NULL) {
                   12289, 12300, 22269, 22303, 20132, 36890, 30465),
                 multiple = FALSE),
       " {source_service}",
-      intToUtf8(c(65288, 12459, 12486, 12468, 12522, 21517, 65289,
+      intToUtf8(c(65288, 12487, 12540, 12479, 21517, 65289,
                   12301, 12434, 12418, 12392, 12395, 21152, 24037,
                   32773, 12364, 20316, 25104),
                 multiple = FALSE),
@@ -353,7 +353,7 @@ check_dl_comment <- function(source = NULL) {
         multiple = FALSE)),
       source_url = dplyr::case_when(
         source == "isj" ~ "https://nlftp.mlit.go.jp/isj/agreement.html",
-        source == "ksj" ~ "https://nlftp.mlit.go.jp/ksj/other/yakkan.html"
+        source == "ksj" ~ "https://nlftp.mlit.go.jp/ksj/other/agreement.html"
       )
     ),
     call. = FALSE

--- a/R/utils.R
+++ b/R/utils.R
@@ -403,3 +403,11 @@ ksj_common_meshes <- function(identifier) {
       names()
   )
 }
+
+prefcode_validate <- function(pref_code) {
+  codes <-
+    sapply(seq(1, 47, 1), sprintf, fmt = "%d")
+  if (identical(codes[codes %in% pref_code], character(0)))
+    rlang::abort("jis_code must be start a integer or as character from 1 to 47.")
+  as.numeric(pref_code)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,24 +41,43 @@ install.packages("kuniumi", repos = "https://uribo.r-universe.dev")
 
 ```{r, echo=TRUE, eval=FALSE}
 library(kuniumi)
-library(dplyr)
 
-kuniumi:::ksj_data_url("N03") %>% 
-  filter(year == "2015", datum == "1", areaCode == "33") %>% 
-  pull(zipFileUrl) %>% 
-  download.file(url = .,
-                basename(.))
-  
-files <- 
-  list.files( pattern = ".zip$", full.names = TRUE)
-unzip(files, exdir = stringr::str_remove(basename(files), ".zip"))
-unlink(files)
-
-stringr::str_remove(basename(files), ".zip") %>% 
-  list.files(recursive = TRUE, 
-             pattern = ".shp", 
-             full.names = TRUE) %>% 
-  read_ksj_n03(path = .)
+read_ksj_n03(.pref_code = 33)
+#> trying URL 'https://nlftp.mlit.go.jp/ksj/gml/data/N03/N03-2015/N03-150101_33_GML.zip'
+#> Content type 'application/zip' length 2968333 bytes (2.8 MB)
+#> ==================================================
+#> downloaded 2.8 MB
+#> 
+#> options:        ENCODING=CP932 
+#> Reading layer `N03-15_33_150101' from data source `/private/var/folders/_k/8syww8ls39n5dkvwy1yk8dgc0000gn/T/RtmpNHLfZJ/N03-150101_33_GML/N03-20150101_33_GML/N03-15_33_150101.shp' 
+#>   using driver `ESRI Shapefile'
+#> Simple feature collection with 402 features and 5 fields
+#> Geometry type: POLYGON
+#> Dimension:     XY
+#> Bounding box:  xmin: 133.2668 ymin: 34.29833 xmax: 134.4132 ymax: 35.3529
+#> Geodetic CRS:  JGD2000
+#> Simple feature collection with 402 features and 5 fields
+#> Geometry type: POLYGON
+#> Dimension:     XY
+#> Bounding box:  xmin: 133.2668 ymin: 34.29833 xmax: 134.4132 ymax: 35.3529
+#> Geodetic CRS:  JGD2000
+#> # A tibble: 402 × 6
+#>   prefectureName subPrefectureName countyName
+#> * <chr>          <chr>             <chr>     
+#> 1 岡山県         NA                岡山市    
+#> 2 岡山県         NA                岡山市    
+#> 3 岡山県         NA                岡山市    
+#> 4 岡山県         NA                岡山市    
+#> 5 岡山県         NA                岡山市    
+#> # ℹ 397 more rows
+#> # ℹ 3 more variables: cityName <chr>,
+#> #   administrativeAreaCode <chr>,
+#> #   geometry <POLYGON [°]>
+#> # ℹ Use `print(n = ...)` to see more rows
+#> Warning message:
+#> このサービスは、「国土交通省 国土数値情報（カテゴリ名）」をもとに加工者が作成
+#> 以下の国土数値情報ダウンロードサービスの利用規約をご確認の上ご利用ください：
+#> https://nlftp.mlit.go.jp/ksj/other/agreement.html 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 
 ## 対象データ
 
--   国土交通省
-    [国土数値情報ダウンロードサービス](https://nlftp.mlit.go.jp/ksj/)
--   国土交通省
-    [位置参照情報ダウンロードサービス](https://nlftp.mlit.go.jp/isj/index.html)
+- 国土交通省
+  [国土数値情報ダウンロードサービス](https://nlftp.mlit.go.jp/ksj/)
+- 国土交通省
+  [位置参照情報ダウンロードサービス](https://nlftp.mlit.go.jp/isj/index.html)
 
 ## インストール
 
@@ -32,24 +32,43 @@ install.packages("kuniumi", repos = "https://uribo.r-universe.dev")
 
 ``` r
 library(kuniumi)
-library(dplyr)
 
-kuniumi:::ksj_data_url("N03") %>% 
-  filter(year == "2015", datum == "1", areaCode == "33") %>% 
-  pull(zipFileUrl) %>% 
-  download.file(url = .,
-                basename(.))
-  
-files <- 
-  list.files( pattern = ".zip$", full.names = TRUE)
-unzip(files, exdir = stringr::str_remove(basename(files), ".zip"))
-unlink(files)
-
-stringr::str_remove(basename(files), ".zip") %>% 
-  list.files(recursive = TRUE, 
-             pattern = ".shp", 
-             full.names = TRUE) %>% 
-  read_ksj_n03(path = .)
+read_ksj_n03(.pref_code = 33)
+#> trying URL 'https://nlftp.mlit.go.jp/ksj/gml/data/N03/N03-2015/N03-150101_33_GML.zip'
+#> Content type 'application/zip' length 2968333 bytes (2.8 MB)
+#> ==================================================
+#> downloaded 2.8 MB
+#> 
+#> options:        ENCODING=CP932 
+#> Reading layer `N03-15_33_150101' from data source `/private/var/folders/_k/8syww8ls39n5dkvwy1yk8dgc0000gn/T/RtmpNHLfZJ/N03-150101_33_GML/N03-20150101_33_GML/N03-15_33_150101.shp' 
+#>   using driver `ESRI Shapefile'
+#> Simple feature collection with 402 features and 5 fields
+#> Geometry type: POLYGON
+#> Dimension:     XY
+#> Bounding box:  xmin: 133.2668 ymin: 34.29833 xmax: 134.4132 ymax: 35.3529
+#> Geodetic CRS:  JGD2000
+#> Simple feature collection with 402 features and 5 fields
+#> Geometry type: POLYGON
+#> Dimension:     XY
+#> Bounding box:  xmin: 133.2668 ymin: 34.29833 xmax: 134.4132 ymax: 35.3529
+#> Geodetic CRS:  JGD2000
+#> # A tibble: 402 × 6
+#>   prefectureName subPrefectureName countyName
+#> * <chr>          <chr>             <chr>     
+#> 1 岡山県         NA                岡山市    
+#> 2 岡山県         NA                岡山市    
+#> 3 岡山県         NA                岡山市    
+#> 4 岡山県         NA                岡山市    
+#> 5 岡山県         NA                岡山市    
+#> # ℹ 397 more rows
+#> # ℹ 3 more variables: cityName <chr>,
+#> #   administrativeAreaCode <chr>,
+#> #   geometry <POLYGON [°]>
+#> # ℹ Use `print(n = ...)` to see more rows
+#> Warning message:
+#> このサービスは、「国土交通省 国土数値情報（カテゴリ名）」をもとに加工者が作成
+#> 以下の国土数値情報ダウンロードサービスの利用規約をご確認の上ご利用ください：
+#> https://nlftp.mlit.go.jp/ksj/other/agreement.html 
 ```
 
 ## クレジット

--- a/data-raw/city_address.R
+++ b/data-raw/city_address.R
@@ -118,7 +118,7 @@ df_address_tmp <-
 
 
 # geocoding ---------------------------------------------------------------
-library(jpndistrict)
+# library(jpndistrict)
 library(sf)
 df_isj_a <-
   readr::read_rds("~/Documents/projects2019/jp-address/data-raw/isj_2018a.rds")

--- a/data-raw/codelist.R
+++ b/data-raw/codelist.R
@@ -20,10 +20,10 @@ extract_ksj_codelist <- function(url, names = NULL) {
 }
 
 l_ksj_landuse <-
-  list(`2016` = "http://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-09.html",
-       `2006`   = "http://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-YY.html",
-       `1987`   = "http://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-88.html",
-       `1976`   = "http://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-77.html") %>%
+  list(`2016` = "https://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-09.html",
+       `2006`   = "https://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-YY.html",
+       `1987`   = "https://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-88.html",
+       `1976`   = "https://nlftp.mlit.go.jp/ksj/gml/codelist/LandUseCd-77.html") %>%
   purrr::map(extract_ksj_codelist,
              names = c("code", "type", "definition"))
 
@@ -71,7 +71,7 @@ l_ksj_landuse <-
 
 # Pref (P12)
 l_ksj_pref <-
-  extract_ksj_codelist("http://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html") %>% {
+  extract_ksj_codelist("https://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html") %>% {
   bind_rows(
     .[, c(1, 2)],
     .[, c(3, 4)]
@@ -81,16 +81,16 @@ l_ksj_pref <-
   purrr::set_names(c("コード", "対応する内容"))
 # AdminArea (P12)
 l_ksj_adminarea <-
-  extract_ksj_codelist("http://nlftp.mlit.go.jp/ksj/gml/codelist/AdminAreaCd.html")
+  extract_ksj_codelist("https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminAreaCd.html")
 # tourismResource (P12)
 l_ksj_tourismresource <-
-  extract_ksj_codelist("http://nlftp.mlit.go.jp/ksj/gml/codelist/tourismResourceCategoryCd.html")
+  extract_ksj_codelist("https://nlftp.mlit.go.jp/ksj/gml/codelist/tourismResourceCategoryCd.html")
 # Naturalfeature (P19)
 l_ksj_naturalfeature <-
-  extract_ksj_codelist("http://nlftp.mlit.go.jp/ksj/gml/codelist/NaturalfeatureCd.html")
+  extract_ksj_codelist("https://nlftp.mlit.go.jp/ksj/gml/codelist/NaturalfeatureCd.html")
 # Naturalscene (P19)
 l_ksj_naturalscene <-
-  list(extract_ksj_codelist("http://nlftp.mlit.go.jp/ksj/gml/codelist/NaturalsceneCd.html"))
+  list(extract_ksj_codelist("https://nlftp.mlit.go.jp/ksj/gml/codelist/NaturalsceneCd.html"))
 
 ksj_code_list <-
   list(

--- a/kuniumi.Rproj
+++ b/kuniumi.Rproj
@@ -20,4 +20,4 @@ PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
 
-UseNativePipeOperator: No
+UseNativePipeOperator: Yes


### PR DESCRIPTION
## Summary

プロジェクト再開に向けて、各種の情報を更新

- R (>=4.1)での実行を求めるように変更。開発においてもベースパイプ演算子の利用を推奨する。ただしmagrittrパイプを使った処理はまだ残っている。
- `jpndistrict:::prefcode_validate()`はパッケージ内部の関数として処理するように。（jpndistrictへの依存をなくした）